### PR TITLE
Change /app/templates/.jshintrc to be "indent": 2 instead of 4

### DIFF
--- a/app/templates/.jshintrc
+++ b/app/templates/.jshintrc
@@ -7,7 +7,7 @@
   "curly": false,
   "eqeqeq": true,
   "immed": true,
-  "indent": 4,
+  "indent": 2,
   "latedef": true,
   "newcap": false,
   "noarg": true,


### PR DESCRIPTION
Currently is set to 4, which conflicts with `.editorconfig`
