### PR TITLE
Remove modulesDirectories from webpack config.

### DIFF
--- a/app/templates/.taskconfig
+++ b/app/templates/.taskconfig
@@ -91,9 +91,6 @@ export default {
       root: [
         path.join(sourceDir, '_assets', 'javascripts'),
         path.join(sourceDir, '_data')
-      ],
-      modulesDirectories: [
-        modulesDir
       ]
     },
     plugins: [new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js')].concat(env.debug ? [] : [


### PR DESCRIPTION
Was causing issues with dependency conflicts:
https://github.com/andrewscwei/generator-vars-jekyll/issues/8
