### PR TITLE
Use --incremental option to Jekyll

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -9,7 +9,7 @@
     "test": "mocha tests --recursive --reporter spec",
     "clean": "rimraf public",
     "build": "npm run clean && bundle exec jekyll build --verbose && gulp",
-    "dev": "npm run clean && (bundle exec jekyll build --drafts --verbose --watch & NODE_ENV=development gulp --watch & browser-sync start --server=public --files=public/**/*.{html,js,css,jpg,jpeg,gif,png,svg,ogv,mp4} --no-open --no-notify --logLevel=info --port=${PORT:-3000})",
+    "dev": "npm run clean && (bundle exec jekyll build --drafts --verbose --watch --incremental & NODE_ENV=development gulp --watch & browser-sync start --server=public --files=public/**/*.{html,js,css,jpg,jpeg,gif,png,svg,ogv,mp4} --no-open --no-notify --logLevel=info --port=${PORT:-3000})",
     "prod": "export NODE_ENV=production && npm run build && npm start"
   },
   "engines": {


### PR DESCRIPTION
http://idratherbewriting.com/2015/11/04/jekyll-30-released-incremental-regeneration-rocks/

"Enable the experimental incremental build feature. Incremental build only re-builds posts and pages that have changed, resulting in significant performance improvements for large sites, but may also break site generation in certain cases."
Source: https://jekyllrb.com/docs/configuration/
